### PR TITLE
ci(github): add workflow to mirror main branch

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,20 @@
+name: Push to Mirror
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    if: github.repository == 'Epitech-CI/Gomoku'
+    steps:
+      - name: Checkout complet
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Push to mirror
+        run: |
+          git remote add school https://oauth2:${{ secrets.MIRROR_TOKEN }}@github.com/EpitechPGE3-2025/G-AIA-500-BDX-5-1-gomoku-7.git
+          git push --force --mirror school


### PR DESCRIPTION
This adds a GitHub Actions workflow that pushes all changes from the main
branch to a mirror repository when changes are pushed to the main branch.
The workflow only runs for the Epitech-CI/Gomoku repository and uses a secret token for authentication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic repository mirroring to a secondary location on each push to the main branch, enabling synchronized backups and improved repository redundancy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->